### PR TITLE
Fix catching all exceptions to specific one

### DIFF
--- a/onboarding/apps/accounts/forms.py
+++ b/onboarding/apps/accounts/forms.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.forms import AuthenticationForm
+from django.core.exceptions import ObjectDoesNotExist
 
 from .models import User
 
@@ -12,6 +13,6 @@ class UserLoginForm(AuthenticationForm):
             valid = user.check_password(password)
             if not valid:
                 self.add_error('password', 'Invalid password.')
-        except:
+        except ObjectDoesNotExist:
             self.add_error('username', 'User does not exist')
         return super().clean()

--- a/onboarding/apps/accounts/forms.py
+++ b/onboarding/apps/accounts/forms.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.forms import AuthenticationForm
-from django.core.exceptions import ObjectDoesNotExist
 
 from .models import User
 
@@ -13,6 +12,6 @@ class UserLoginForm(AuthenticationForm):
             valid = user.check_password(password)
             if not valid:
                 self.add_error('password', 'Invalid password.')
-        except ObjectDoesNotExist:
+        except User.DoesNotExist:
             self.add_error('username', 'User does not exist')
         return super().clean()


### PR DESCRIPTION
### Changes done
- Changed empty except block to except User.DoesNotExist.

### Reason for the changes
- catching exception without any specific case will lead to difficulties to find bugs in later stages since it will be covering unexpected errors as well.

Fixes #4 

### Guidelines
- [x] PEP8(Python)
- [x] Is each logical block separated with a line break?
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?